### PR TITLE
Fix "Time Dimensions" button

### DIFF
--- a/style.css
+++ b/style.css
@@ -110,6 +110,7 @@ img {
   gap: 10px;
   margin-left: 8px;
   flex-basis: 25%;
+  z-index: 1;
 }
 
 #buttonsContainer {


### PR DESCRIPTION
Put `z-index: 1;` for `#tabsContainer`, this seems to solve the issue where the TD tab button is unclickable, however it does have the side effect that, if your monitor is small enough, the tabs will go over the daily and theme buttons (the game currently doesn't support that anyway so this should be OK, just keeping a note here). I suspect this has actually been an issue for a long time, but it just came up now because of the "Latest Drops" button, which made `#footerContainer` slightly taller (the exact height for which the button is unclickable matches), and the "Artifacts" button which pushed shop and TD one button lower.